### PR TITLE
Add category code attribute to admin panel

### DIFF
--- a/view/adminhtml/ui_component/category_form.xml
+++ b/view/adminhtml/ui_component/category_form.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <fieldset name="general">
+        <field name="code">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="sortOrder" xsi:type="number">30</item>
+                    <item name="dataType" xsi:type="string">string</item>
+                    <item name="formElement" xsi:type="string">input</item>
+                    <item name="label" xsi:type="string" translate="true">Category Code</item>
+                </item>
+            </argument>
+        </field>
+    </fieldset>
+</form>


### PR DESCRIPTION
This is how to get attributes into the category form, pretty neat - if a little too specific to categories.

http://magento.stackexchange.com/questions/126452/adding-ui-for-third-party-category-attributes-in-magento-2-1
