### PR TITLE
Update magento/framework requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
       }
   },
   "require": {
-      "magento/framework": "^100.1.0",
+      "magento/framework": "^100.1.0|^101",
       "magento/module-catalog": "^100|^101",
       "snowio/magento2-lock": "^1.0.0"
   },


### PR DESCRIPTION
Update magento/framework requirement in composer.json. This is to remove issues when upgrading magento to version 2.2.0. Example error displayed below: 

```
  Problem 1
    - ampersand/magento2-react-fredhopper 1.2.0 requires ampersand/magento2-react-lib ^1.3 -> satisfiable by ampersand/magento2-react-lib[1.3.0].
    - Installation request for ampersand/magento2-react-fredhopper 1.2.0 -> satisfiable by ampersand/magento2-react-fredhopper[1.2.0].
    - Conclusion: remove magento/framework 101.0.0-rc23
    - Conclusion: don't install magento/framework 101.0.0-rc23
    - ampersand/magento2-react-lib 1.3.0 requires magento/framework 100.1.* -> satisfiable by magento/framework[100.1.0-rc1, 100.1.0-rc2, 100.1.0-rc3, 100.1.0, 100.1.1, 100.1.2, 100.1.3, 100.1.4, 100.1.5, 100.1.6, 100.1.7, 100.1.8].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.0-rc1].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.0-rc2].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.0-rc3].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.0].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.1].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.2].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.3].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.4].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.5].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.6].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.7].
    - Can only install one of: magento/framework[101.0.0-rc23, 100.1.8].
    - Installation request for magento/framework (locked at 101.0.0-rc23) -> satisfiable by magento/framework[101.0.0-rc23].
```