### PR TITLE
Update module-catalog requirement for magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   },
   "require": {
       "magento/framework": "^100.1.0|^101",
-      "magento/module-catalog": "^100|^101",
+      "magento/module-catalog": "^100|^101|^102",
       "snowio/magento2-lock": "^1.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
Update module-catalog requirement for magento 2.2: 
```
  Problem 1
    - Conclusion: don't install ampersand/category-code 1.2.0
    - Conclusion: remove magento/framework 101.0.0-rc23
    - Installation request for ampersand/category-code 1.2.0 -> satisfiable by ampersand/category-code[1.2.0].
    - Conclusion: don't install magento/framework 101.0.0-rc23
    - ampersand/category-code 1.2.0 requires magento/module-catalog ^100|^101 -> satisfiable by magento/module-catalog[100.0.2, 100.0.3, 100.0.4, 100.0.5, 100.0.6, 100.0.7, 101.0.0-rc1, 101.0.0-rc2, 101.0.0-rc3, 101.0.0, 100.0.8, 100.0.9, 101.0.1, 100.0.10, 101.0.2, 101.0.3, 100.0.11, 101.0.4, 100.0.12, 101.0.5, 100.0.13, 101.0.6, 101.0.7, 100.0.14, 101.0.8, 101.1.0-rc20].
```

Passed composer validation.