### PR TITLE
Work around flat table to load category code (B: TBP-244)

### DIFF
--- a/Observer/AfterCategoryLoad.php
+++ b/Observer/AfterCategoryLoad.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Ampersand\CategoryCode\Observer;
+
+class AfterCategoryLoad implements \Magento\Framework\Event\ObserverInterface
+{
+    /** @var \Magento\Catalog\Model\Indexer\Category\Flat\State */
+    private $flatState;
+    /** @var \Ampersand\CategoryCode\Model\Category\ReadHandler */
+    private $categoryReadHandler;
+
+    public function __construct(
+        \Magento\Catalog\Model\Indexer\Category\Flat\State $flatState,
+        \Ampersand\CategoryCode\Model\Category\ReadHandler $categoryReadHandler
+    ) {
+        $this->flatState = $flatState;
+        $this->categoryReadHandler = $categoryReadHandler;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        /**
+         * Work around flat table $model->load() to load category code just like EAV does
+         *
+         * @see \Magento\Catalog\Model\Category::_construct
+         * @see \Ampersand\CategoryCode\Model\Category\ReadHandler::execute
+         */
+        if (!$this->flatState->isAvailable()) {
+            return;
+        }
+
+        /** @var \Magento\Catalog\Model\Category $category */
+        $category = $observer->getData('category');
+
+        $this->categoryReadHandler->execute($category);
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,4 +3,7 @@
     <event name="magento_catalog_api_data_categoryinterface_save_after">
         <observer name="save_code_to_id_mapping_after_category_save" instance="Ampersand\CategoryCode\Observer\AfterCategorySave" />
     </event>
+    <event name="catalog_category_load_after">
+        <observer name="Ampersand\CategoryCode\Observer\AfterCategoryLoad" instance="Ampersand\CategoryCode\Observer\AfterCategoryLoad" />
+    </event>
 </config>


### PR DESCRIPTION
[TBP-244](https://ampersand.atlassian.net/browse/TBP-244)

# Objective

Vanilla flat table does not invoke EAV's ReadHandler and fail to make flat table transparent.

As a result, below code will result in error if flat table is enabled.

```php
//  PHP Fatal error:  Uncaught Error: Call to a member function getCode() on null
$category->getExtensionAttributes()->getCode();
```

# Task

- [x] Create observer to invoke Read Handler if flat table is enabled
