### PR TITLE
Pass store ID to category repository `get` method

### DIFF
--- a/Model/CodedCategoryRepository.php
+++ b/Model/CodedCategoryRepository.php
@@ -51,7 +51,7 @@ class CodedCategoryRepository implements CodedCategoryRepositoryInterface
             throw new NoSuchEntityException;
         }
 
-        return $this->categoryRepository->get($categoryId);
+        return $this->categoryRepository->get($categoryId, $storeId);
     }
 
     public function deleteByIdentifier($categoryCode)


### PR DESCRIPTION
The current implementation of `\Ampersand\CategoryCode\Model\CodedCategoryRepository::get` does not pass the store ID to `$this->categoryRepository->get()`. This has the affect of only ever being able to retrieve categories for the "current" (as determined by the store manager) store.

This PR passes the store ID so we can use store specific categories/tables.