### PR TITLE
Fix static analysis issues

### DIFF
--- a/Model/CategoryCode.php
+++ b/Model/CategoryCode.php
@@ -11,6 +11,9 @@ class CategoryCode extends DataObject implements CategoryCodeInterface
         return $this->getData(self::CATEGORY_CODE);
     }
 
+    /**
+     * @return $this
+     */
     public function setCategoryCode($code)
     {
         return $this->setData(self::CATEGORY_CODE, $code);
@@ -21,6 +24,9 @@ class CategoryCode extends DataObject implements CategoryCodeInterface
         return $this->getData(self::CATEGORY_ID);
     }
 
+    /**
+     * @return $this
+     */
     public function setCategoryId($id)
     {
         return $this->setData(self::CATEGORY_ID, $id);

--- a/Model/CodedCategoryProductLink.php
+++ b/Model/CodedCategoryProductLink.php
@@ -8,9 +8,12 @@ class CodedCategoryProductLink extends AbstractExtensibleModel implements CodedC
 {
     public function getSku()
     {
-       return $this->_getData(self::SKU);
+        return $this->_getData(self::SKU);
     }
 
+    /**
+     * @return \Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface
+     */
     public function setSku($sku)
     {
         return $this->setData(self::SKU, $sku);
@@ -21,6 +24,9 @@ class CodedCategoryProductLink extends AbstractExtensibleModel implements CodedC
         return $this->_getData(self::POSITION);
     }
 
+    /**
+     * @return \Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface
+     */
     public function setPosition($position)
     {
         return $this->setData(self::POSITION, $position);
@@ -31,6 +37,9 @@ class CodedCategoryProductLink extends AbstractExtensibleModel implements CodedC
         return $this->_getData(self::CATEGORY_CODE);
     }
 
+    /**
+     * @return \Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface
+     */
     public function setCategoryCode($categoryCode)
     {
         return $this->setData(self::CATEGORY_CODE, $categoryCode);
@@ -41,6 +50,9 @@ class CodedCategoryProductLink extends AbstractExtensibleModel implements CodedC
         return $this->_getExtensionAttributes();
     }
 
+    /**
+     * @return \Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface
+     */
     public function setExtensionAttributes(\Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkExtensionInterface $extensionAttributes)
     {
         return $this->_setExtensionAttributes($extensionAttributes);


### PR DESCRIPTION
### Description
Fixes the following static analysis issues:
```
 ------ -----------------------------------------------------------------------------------
  Line   vendor/ampersand/category-code/Model/CategoryCode.php
 ------ -----------------------------------------------------------------------------------
  16     Method Ampersand\CategoryCode\Model\CategoryCode::setCategoryCode() should return
         $this(Ampersand\CategoryCode\Api\Data\CategoryCodeInterface) but returns
         $this(Ampersand\CategoryCode\Model\CategoryCode).
  26     Method Ampersand\CategoryCode\Model\CategoryCode::setCategoryId() should return
         $this(Ampersand\CategoryCode\Api\Data\CategoryCodeInterface) but returns
         $this(Ampersand\CategoryCode\Model\CategoryCode).
 ------ -----------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------------------
  Line   vendor/ampersand/category-code/Model/CodedCategoryProductLink.php
 ------ ------------------------------------------------------------------------------------------------------
  16     Method Ampersand\CategoryCode\Model\CodedCategoryProductLink::setSku() should return
         $this(Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface) but returns
         $this(Ampersand\CategoryCode\Model\CodedCategoryProductLink).
  26     Method Ampersand\CategoryCode\Model\CodedCategoryProductLink::setPosition() should return
         $this(Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface) but returns
         $this(Ampersand\CategoryCode\Model\CodedCategoryProductLink).
  36     Method Ampersand\CategoryCode\Model\CodedCategoryProductLink::setCategoryCode() should return
         $this(Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface) but returns
         $this(Ampersand\CategoryCode\Model\CodedCategoryProductLink).
  46     Method Ampersand\CategoryCode\Model\CodedCategoryProductLink::setExtensionAttributes() should return
         $this(Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkInterface) but returns
         $this(Ampersand\CategoryCode\Model\CodedCategoryProductLink).
 ------ ------------------------------------------------------------------------------------------------------
```