### PR TITLE
Fix additional static analysis error

### DIFF
--- a/Api/Data/CodedCategoryProductLinkInterface.php
+++ b/Api/Data/CodedCategoryProductLinkInterface.php
@@ -52,7 +52,7 @@ interface CodedCategoryProductLinkInterface extends ExtensibleDataInterface
     /**
      * Retrieve existing extension attributes object.
      *
-     * @return \Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkExtensionInterface|null
+     * @return \Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkExtensionInterface|\Magento\Framework\Api\ExtensionAttributesInterface|null
      */
     public function getExtensionAttributes();
 


### PR DESCRIPTION
### Description
Fix an additional static analysis issue:
```
 ------ ------------------------------------------------------------------------------------------------------
  Line   vendor/ampersand/category-code/Model/CodedCategoryProductLink.php
 ------ ------------------------------------------------------------------------------------------------------
  50     Method Ampersand\CategoryCode\Model\CodedCategoryProductLink::getExtensionAttributes() should return
         Ampersand\CategoryCode\Api\Data\CodedCategoryProductLinkExtensionInterface|null but returns
         Magento\Framework\Api\ExtensionAttributesInterface.
 ------ ------------------------------------------------------------------------------------------------------
```