### PR TITLE
Add getList for coded category repository

### DIFF
--- a/Api/CodedCategoryRepositoryInterface.php
+++ b/Api/CodedCategoryRepositoryInterface.php
@@ -29,6 +29,16 @@ interface CodedCategoryRepositoryInterface
     public function get($categoryCode, $storeId = null);
 
     /**
+     * Get list of categories from search criteria
+     *
+     * @param array $categoryCodes
+     * @param array|null $attributesToSelect
+     * @return \Magento\Catalog\Model\ResourceModel\Category\Collection
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getList(array $categoryCodes, array $attributesToSelect = null);
+
+    /**
      * Delete category by code
      *
      * @param string $categoryCode


### PR DESCRIPTION
### Description

Add `getList` for coded category repository. This function does not make use of search criteria as the category repository does not implement a useable `getList`. This methodology is also backwards compatible for all versions of M2.