### PR TITLE
Update CodedCategoryRepository.php

### DIFF
--- a/Api/CodedCategoryRepositoryInterface.php
+++ b/Api/CodedCategoryRepositoryInterface.php
@@ -36,7 +36,7 @@ interface CodedCategoryRepositoryInterface
      * @return \Magento\Catalog\Model\ResourceModel\Category\Collection
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getList(array $categoryCodes, array $attributesToSelect = null);
+    public function getList(array $categoryCodes, $attributesToSelect = null);
 
     /**
      * Delete category by code

--- a/Model/CodedCategoryRepository.php
+++ b/Model/CodedCategoryRepository.php
@@ -85,7 +85,7 @@ class CodedCategoryRepository implements CodedCategoryRepositoryInterface
      * @return \Magento\Catalog\Model\ResourceModel\Category\Collection
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getList(array $categoryCodes, $attributesToSelect = null)
+    public function getList(array $categoryCodes, array $attributesToSelect = null)
     {
         $collection = $this->categoryCollectionFactory->create();
         $categoryIds = array_values($this->categoryCodeRepository->getIds($categoryCodes));

--- a/Model/CodedCategoryRepository.php
+++ b/Model/CodedCategoryRepository.php
@@ -85,7 +85,7 @@ class CodedCategoryRepository implements CodedCategoryRepositoryInterface
      * @return \Magento\Catalog\Model\ResourceModel\Category\Collection
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getList(array $categoryCodes, array $attributesToSelect = null)
+    public function getList(array $categoryCodes, $attributesToSelect = null)
     {
         $collection = $this->categoryCollectionFactory->create();
         $categoryIds = array_values($this->categoryCodeRepository->getIds($categoryCodes));


### PR DESCRIPTION
Locally on dev mode this happened

```php
To exit the shell, type ^D.
Psy Shell v0.9.9 (PHP 7.1.25 — cli) by Justin Hileman
>>> $di->get(Ampersand\CategoryCode\Model\CodedCategoryRepository::class);
PHP Fatal error:  Declaration of Ampersand\CategoryCode\Model\CodedCategoryRepository::getList(array $categoryCodes, $attributesToSelect = NULL) must be compatible with Ampersand\CategoryCode\Api\CodedCategoryRepositoryInterface::getList(array $categoryCodes, ?array $attributesToSelect = NULL) in /Users/lukerodgers/src/vendor/ampersand/category-code/Model/CodedCategoryRepository.php on line 11

Fatal error: Declaration of Ampersand\CategoryCode\Model\CodedCategoryRepository::getList(array $categoryCodes, $attributesToSelect = NULL) must be compatible with Ampersand\CategoryCode\Api\CodedCategoryRepositoryInterface::getList(array $categoryCodes, ?array $attributesToSelect = NULL) in /Users/lukerodgers/src/vendor/ampersand/category-code/Model/CodedCategoryRepository.php on line 11
>>>
```

But on prod it wasnt that big a deal apparently

```php
To exit the shell, type ^D.
Psy Shell v0.9.9 (PHP 7.2.19 — cli) by Justin Hileman
>>> $di->get(Ampersand\CategoryCode\Model\CodedCategoryRepository::class);
=> Ampersand\CategoryCode\Model\CodedCategoryRepository {#16933}
>>>
```

Should still be fixed and pulled in