### PR TITLE
Delete return statement

### DIFF
--- a/Model/CodedCategoryRepository.php
+++ b/Model/CodedCategoryRepository.php
@@ -60,7 +60,6 @@ class CodedCategoryRepository implements CodedCategoryRepositoryInterface
         } finally {
             $this->releaseLock($categoryCode);
         }
-        return true;
     }
 
     /**


### PR DESCRIPTION
Delete return statement to fix the static analysis.

`Method Ampersand\CategoryCode\Model\CodedCategoryRepository::save() with return type void returns true but should not return anything. `