### PR TITLE
Ensure observer only fires on an installed magento instance

### DIFF
--- a/Observer/AfterCategorySave.php
+++ b/Observer/AfterCategorySave.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ampersand\CategoryCode\Observer;
 
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
@@ -9,10 +10,12 @@ use Ampersand\CategoryCode\Model\CategoryCodeRepository;
 class AfterCategorySave implements ObserverInterface
 {
     private $categoryCodeRepository;
+    private $deploymentConfig;
 
-    public function __construct(CategoryCodeRepository $categoryCodeRepository)
+    public function __construct(CategoryCodeRepository $categoryCodeRepository, DeploymentConfig $deploymentConfig)
     {
         $this->categoryCodeRepository = $categoryCodeRepository;
+        $this->deploymentConfig = $deploymentConfig;
     }
 
     public function execute(Observer $observer)
@@ -20,7 +23,7 @@ class AfterCategorySave implements ObserverInterface
         /** @var CategoryInterface $category */
         $category = $observer->getDataByKey('entity');
 
-        if ($extensionAttributes = $category->getExtensionAttributes()) {
+        if ($this->deploymentConfig->isAvailable() && $extensionAttributes = $category->getExtensionAttributes()) {
             if (null !== $code = $extensionAttributes->getCode()) {
                 $this->categoryCodeRepository->save($code, $category->getId());
             }


### PR DESCRIPTION
Ensure observer only fires if magento is actually deployed and runnable. 

Fixes installer for integration tests