### PR TITLE
Fix travis error on make test-static-analysis

### DIFF
--- a/Model/CodedCategoryRepository.php
+++ b/Model/CodedCategoryRepository.php
@@ -64,7 +64,7 @@ class CodedCategoryRepository implements CodedCategoryRepositoryInterface
 
     /**
      * @param string $categoryCode
-     * @param null $storeId
+     * @param int $storeId
      * @return CategoryInterface
      * @throws NoSuchEntityException
      */


### PR DESCRIPTION
### Description

On `make test-static-analysis` the following error is thrown in O4B:

```
Parameter #2 $storeId (null) of method
         Ampersand\CategoryCode\Model\CodedCategoryRepository::get() should be
         compatible with parameter $storeId (int) of method
         Ampersand\CategoryCode\Api\CodedCategoryRepositoryInterface::get()
```